### PR TITLE
Extend SpeculaCore with backend modules and full pipeline integration

### DIFF
--- a/src/SpeculaCore.bsv
+++ b/src/SpeculaCore.bsv
@@ -7,6 +7,7 @@ package SpeculaCore;
   import RenameStage::*;
   import PRF::*;
   import FreeList::*;
+  import ReservationStation::*;
 
   module mkSpeculaCore(Empty);
     IfcFetchUnit fetch <- mkFetchUnit;
@@ -15,6 +16,7 @@ package SpeculaCore;
     RenameStage_IFC rename <- mkRenameStage;
     PRF prf <- mkPRF;
     FreeList_IFC freelist <- mkFreeList; 
+    ReservationStationIfc rs <- mkReservationStation;
     
     let maxPC = 32'h00000100;
 
@@ -61,6 +63,30 @@ package SpeculaCore;
         $display("[PRF Test] PRF[5] = %x", v);
       end else begin
         $display("[PRF Test] PRF[5] = BAD");
+      end
+    endrule
+
+    rule testRS (pc == 0);
+      RSEntry e = RSEntry {
+        op: ALU_ADD,
+        src1: PhysRegTag'(1),
+        src1Ready: True,
+        src2: PhysRegTag'(2),
+        src2Ready: True,
+        dest: PhysRegTag'(3),
+        robTag: ROBTag { idx: 0 } 
+      };
+
+      rs.enq(e);
+      $display("[Specula] Enqueued RSEntry: dest=%0d src1=%0d src2=%0d", e.dest, e.src1, e.src2);
+    endrule
+
+    rule testRS_deq(pc == 4);
+      if(rs.notEmpty) begin
+        let e <- rs.deq();
+        $display("[Specula] Dequeued RSEntry: dest=%0d src1=%0d src2=%0d", e.dest, e.src1, e.src2);
+      end else begin
+        $display("[Specula] Reservation Station is empty, cannot dequeue");
       end
     endrule
 

--- a/src/backend/ALU.bsv
+++ b/src/backend/ALU.bsv
@@ -1,12 +1,68 @@
 package ALU;
 
-  interface IfcALU;
-    method Action dummy();
+  import Common::*;
+  import FIFOF::*;
+
+  typedef struct {
+    ALUOp op;
+    Data a;
+    Data b;
+    PhysRegTag dest;
+    ROBTag robTag;
+  } ALUReq deriving (Bits, FShow);
+
+  typedef struct {
+    Data result;
+    PhysRegTag dest;
+    ROBTag robTag;
+  } ALUResp deriving (Bits, FShow);
+
+  interface ALU_IFC;
+    method Bool notFull();
+    method Bool notEmpty();
+    method Action enq(ALUReq r);
+    method ActionValue#(ALUResp) deq();
   endinterface
 
-  module mkALU(IfcALU);
-    method Action dummy();
-    endmethod
-  endmodule
+  module mkALU(ALU_IFC);
 
+    FIFOF#(ALUReq) reqQ <- mkFIFOF();
+    FIFOF#(ALUResp) respQ <- mkFIFOF();
+
+    rule do_execute(!respQ.full && !reqQ.empty);
+      let r = reqQ.first; reqQ.deq;
+
+      Data res = 32'd0;
+      case (r.op) 
+        ALU_ADD: res = r.a + r.b;
+        ALU_SUB: res = r.a - r.b;
+        ALU_AND: res = r.a & r.b;
+        ALU_OR: res = r.a | r.b;
+        default: res = 32'd0;
+      endcase
+
+      ALUResp out = ALUResp {
+        result: res, 
+        dest: r.dest,
+        robTag: r.robTag
+      };
+      respQ.enq(out);
+
+      $display("[ALU] op=%0d a=%0d b=%0d -> res=%0d dest=%0d rob=%0d", r.op, r.a, r.b, res, r.dest, r.robTag.idx);
+
+    endrule
+
+    method Bool notFull() = !reqQ.full;
+    method Bool notEmpty() = !respQ.empty;
+
+    method Action enq(ALUReq r);
+      reqQ.enq(r);
+    endmethod
+
+    method ActionValue#(ALUResp) deq();
+      let v = respQ.first; respQ.deq;
+      return v;
+    endmethod
+
+  endmodule
 endpackage

--- a/src/backend/FreeList.bsv
+++ b/src/backend/FreeList.bsv
@@ -5,11 +5,19 @@ package FreeList;
 
   interface FreeList_IFC;
     method ActionValue#(Maybe#(PhysRegTag)) tryAllocate();
+    method Action free(PhysRegTag tag);
+    method Bool hasFree();
   endinterface
 
   module mkFreeList(FreeList_IFC);
+
     Vector#(NUM_PHYS_REGS, Reg#(Bool)) freelist <- replicateM(mkReg(True));
     
+    function Bool orFn(Bool a, Bool b);
+      return a || b;
+    endfunction
+
+
     method ActionValue#(Maybe#(PhysRegTag)) tryAllocate();
       Maybe#(PhysRegTag) result = tagged Invalid;
       Bool allocated = False;
@@ -26,5 +34,14 @@ package FreeList;
       return result;
     endmethod
 
+    method Action free(PhysRegTag tag);
+      freelist[tag] <= True;
+    endmethod
+
+    method Bool hasFree();
+      return foldl(orFn, False, readVReg(freelist));
+    endmethod
+
   endmodule
+
 endpackage

--- a/src/backend/PRF.bsv
+++ b/src/backend/PRF.bsv
@@ -9,15 +9,24 @@ package PRF;
     method Action write(PhysRegTag tag, Data val);
     method Bool isReady(PhysRegTag tag);
     method Action markReady(PhysRegTag tag);
+    method Action clear(PhysRegTag tag);
   endinterface
 
   module mkPRF (PRF);
+
     Vector#(NUM_PHYS_REGS, Reg#(Data)) regs <- replicateM(mkRegU);
     Vector#(NUM_PHYS_REGS, Reg#(Bool)) readyBits <- replicateM(mkReg(False));
 
+    rule init_x0;
+      regs[0] <= 0;
+      readyBits[0] <= True;
+    endrule
+
     method Maybe#(Data) read(PhysRegTag tag);
-      if (readyBits[tag]) return Valid(regs[tag]);
-      else return Invalid;
+      if (readyBits[tag]) 
+        return Valid(regs[tag]);
+      else 
+        return Invalid;
     endmethod
 
     method Action write(PhysRegTag tag, Data val);
@@ -30,6 +39,12 @@ package PRF;
 
     method Action markReady(PhysRegTag tag);
       readyBits[tag] <= True;
+    endmethod
+
+    method Action clear(PhysRegTag tag);
+      if (tag != 0) begin
+        readyBits[tag] <= False;
+      end
     endmethod
 
   endmodule

--- a/src/backend/RenameStage.bsv
+++ b/src/backend/RenameStage.bsv
@@ -1,70 +1,77 @@
 package RenameStage;
 
-import Common::*;
-import ROB::*;
-import RAT::*;
-import Vector::*;
-import FreeList::*;
+  import Common::*;
+  import ROB::*;
+  import RAT::*;
+  import Vector::*;
+  import FreeList::*;
+  import PRF::*;
 
-interface RenameStage_IFC;
-  method Action start(Decoded d);
-  method Decoded getRenamed();
-  method Action testFreeListAlloc();
-endinterface
+  interface RenameStage_IFC;
+    method Action start(Decoded d);
+    method Decoded getRenamed();
+    method Action testFreeListAlloc();
+  endinterface
 
-module mkRenameStage(RenameStage_IFC);
+  module mkRenameStage(RenameStage_IFC);
 
-  ROB_IFC rob <- mkROB();
-  RAT_IFC rat <- mkRAT();
-  FreeList_IFC freelist <- mkFreeList();
+    ROB_IFC       rob      <- mkROB();
+    RAT_IFC       rat      <- mkRAT();
+    FreeList_IFC  freelist <- mkFreeList();
+    PRF           prf      <- mkPRF();
 
-  Decoded testInstr = Decoded {
-    opcode: OP_IMM,
-    rd: 3,
-    rs1: 1,
-    rs2: 0,
-    imm: 5
-  };
+    Decoded testInstr = Decoded {
+      opcode: OP_IMM,
+      rd: 3,
+      rs1: 1,
+      rs2: 0,
+      imm: 5
+    };
 
-  Reg#(Decoded) renamedInstr <- mkReg(testInstr);
-  Reg#(Bool) did <- mkReg(False);
+    Reg#(Decoded) renamedInstr <- mkReg(testInstr);
+    Reg#(Bool)    did          <- mkReg(False);
 
-  rule do_rename (!did);
-    let instr = renamedInstr;
+    rule do_rename (!did);
+      let instr = renamedInstr;
 
-    let rs1_tag = rat.lookup(instr.rs1);
-    let rs2_tag = rat.lookup(instr.rs2);
+      let rs1_tag = rat.lookup(instr.rs1);
+      let rs2_tag = rat.lookup(instr.rs2);
+      let robTag <- rob.allocate(tagged Valid instr.rd);
+      let maybeDest <- freelist.tryAllocate();
 
-    let robTag <- rob.allocate(tagged Valid instr.rd);
+      if (maybeDest matches tagged Valid .pDst) begin
 
-    let maybeTag <- freelist.tryAllocate();
-    $display("[FreeList] Allocated tag: %s", fshow(maybeTag));
+        rat.rename(instr.rd, robTag);
 
-    rat.rename(instr.rd, robTag);
+        $display("[RENAME]");
+        $display("  instr: rd=x%0d, rs1=x%0d, rs2=x%0d, imm=%0d",
+                 instr.rd, instr.rs1, instr.rs2, instr.imm);
+        $display("  RAT rs1 -> %s", fshow(rs1_tag));
+        $display("  RAT rs2 -> %s", fshow(rs2_tag));
+        $display("  allocated ROB tag: %0d", robTag.idx);
+        $display("  allocated PHYS tag (dest): p%0d", pDst);
 
-    $display("[RENAME]");
-    $display("  instr: rd = x%0d, rs1 = x%0d, rs2 = x%0d, imm = %0d", instr.rd, instr.rs1, instr.rs2, instr.imm);
-    $display("  rs1 tag: %s", fshow(rs1_tag));
-    $display("  rs2 tag: %s", fshow(rs2_tag));
-    $display("  allocated ROB tag: %d", robTag.idx);
+        did <= True;
+      end
+      else begin
+        $display("[RENAME] Stall: FreeList empty, cannot allocate dest phys-reg");
+      end
+    endrule
 
-    did <= True;
-  endrule
+    method Action start(Decoded d);
+      renamedInstr <= d;
+      did          <= False;
+    endmethod
 
-  method Action start(Decoded d);
-    renamedInstr <= d;
-    did <= False;
-  endmethod
+    method Decoded getRenamed();
+      return renamedInstr;
+    endmethod
 
-  method Decoded getRenamed();
-    return renamedInstr;
-  endmethod
+    method Action testFreeListAlloc();
+      let maybeTag <- freelist.tryAllocate();
+      $display("[FreeList Test] Allocated tag: %s", fshow(maybeTag));
+    endmethod
 
-  method Action testFreeListAlloc();
-    let maybeTag <- freelist.tryAllocate();
-    $display("[FreeList Test] Allocated tag: %s", fshow(maybeTag));
-  endmethod
-
-endmodule
+  endmodule
 
 endpackage

--- a/src/backend/ReservationStation.bsv
+++ b/src/backend/ReservationStation.bsv
@@ -1,0 +1,78 @@
+package ReservationStation;
+
+  import FIFO::*;
+  import FIFOF::*;
+  import Common::*;
+  import Vector::*;
+
+  typedef 8 RS_SIZE;
+
+  interface ReservationStationIfc;
+    method Action enq(RSEntry entry);
+    method ActionValue#(RSEntry) deq();
+    method Bool notFull;
+    method Bool notEmpty;
+  endinterface
+
+  module mkReservationStation(ReservationStationIfc);
+
+    Reg#(Vector#(RS_SIZE, Maybe#(RSEntry))) slots <- mkReg(replicate(Invalid));
+
+    function Maybe#(UInt#(TLog#(RS_SIZE))) findFree(Vector#(RS_SIZE, Maybe#(RSEntry)) s);
+      Maybe#(UInt#(TLog#(RS_SIZE))) result = Invalid;
+      for (Integer i = 0; i < valueOf(RS_SIZE); i = i + 1) begin
+        if (!isValid(s[i]) && !isValid(result)) begin
+          result = Valid(fromInteger(i)); 
+        end
+      end
+      return result;
+    endfunction
+
+    function Maybe#(UInt#(TLog#(RS_SIZE))) findReady(Vector#(RS_SIZE, Maybe#(RSEntry)) s);
+      Maybe#(UInt#(TLog#(RS_SIZE))) result = Invalid;
+      for (Integer i = 0; i < valueOf(RS_SIZE); i = i + 1) begin
+        if (isValid(s[i])) begin
+          let e = fromMaybe(?, s[i]);
+          if (e.src1Ready && e.src2Ready && !isValid(result))
+            result = Valid(fromInteger(i));
+        end
+      end
+      return result;
+    endfunction
+
+    rule show_rs;
+      for (Integer i = 0; i < valueOf(RS_SIZE); i = i+1) begin
+        if (isValid(slots[i])) begin
+          let e = fromMaybe(?, slots[i]);
+          $display("[RS] Slot %0d: op=%0d dest=%0d src1=%0d ready=%0d src2=%0d ready=%0d rob=%0d", i, e.op, e.dest, e.src1, e.src1Ready, e.src2, e.src2Ready, e.robTag.idx);
+        end
+      end
+    endrule
+
+    method Action enq(RSEntry entry);
+      let freeIdx = findFree(slots);
+      if (isValid(freeIdx)) begin
+        slots[validValue(freeIdx)] <= Valid(entry);
+      end
+      else $display("[RS] Enqueue failed: RS full");
+    endmethod
+
+    method ActionValue#(RSEntry) deq();
+      let readyIdx = findReady(slots);
+      if (isValid(readyIdx)) begin
+        let idx = validValue(readyIdx);
+        let e = fromMaybe(?, slots[idx]);
+        slots[idx] <= Invalid;
+        return e;
+      end 
+      else begin
+        $display("[RS] Dequeue attempted but no ready entry");
+        return ?;
+      end
+    endmethod
+    
+    method Bool notFull = isValid(findFree(slots));
+    method Bool notEmpty = isValid(findReady(slots));
+
+  endmodule
+endpackage

--- a/src/common/Common.bsv
+++ b/src/common/Common.bsv
@@ -4,6 +4,7 @@ package Common;
   typedef Bit#(32) Instruction;
   typedef Bit#(32) Data;
   typedef Maybe#(ROBTag) RATEntry;
+
   typedef enum {
     OP_IMM, OP, LUI, AUIPC, JAL, JALR, BRANCH, LOAD, STORE, MISC_MEM, SYSTEM, INVALID
   } Opcode deriving (Bits, Eq, FShow);
@@ -19,6 +20,11 @@ package Common;
   typedef 6 LogNumPhysRegs;
   typedef 32 NUM_PHYS_REGS;
   typedef Bit#(LogNumPhysRegs) PhysRegTag;
+
+  typedef PhysRegTag ZERO_TAG;
+  function ZERO_TAG zeroTag();
+    return 0;
+  endfunction
 
   function Instruction getInstruction(Bit#(32) pc);
     case(pc)
@@ -51,5 +57,26 @@ package Common;
   typedef struct {
     UInt#(6) idx;
   } ROBTag deriving (Bits, FShow);
+
+  typedef enum {
+    ALU_ADD, ALU_SUB, ALU_AND, ALU_OR
+  } ALUOp deriving (Bits, Eq, FShow);
+
+  typedef struct {
+    ALUOp op;
+    PhysRegTag src1;
+    PhysRegTag src2;
+    PhysRegTag dest;
+  } ALUInstr deriving (Bits, FShow);
+
+  typedef struct {
+    ALUOp op;
+    PhysRegTag src1;
+    Bool src1Ready;
+    PhysRegTag src2;
+    Bool src2Ready;
+    PhysRegTag dest;
+    ROBTag robTag;
+  } RSEntry deriving (Bits, FShow);
 
 endpackage


### PR DESCRIPTION
## Overview

This PR upgrades Specula’s backend for Out-of-Order execution by adding physical register management and integrating core resource allocation modules.

## What’s Added

- Physical Register File (PRF) with read/write and readiness tracking
- FreeList module for physical register tag allocation and reuse
- Updates to Common package for shared `typedefs` and constants
- Integration of PRF and FreeList into SpeculaCore, with debug/test rules for tag allocation and register readiness

> [!NOTE]
> These changes lay the foundation for future backend stages (issue, commit) and confirm correct resource flow and halting in simulation.